### PR TITLE
🌐 Open Online Config 1 with Shadowsocks registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Open Online Config manages and maintains open protocols for the distribution of 
 ## Protocols
 
 0. [README](README.md) (2021-06-27)
+1. [Open Online Config Version 1](docs/0001-open-online-config-v1.md) (2021-07-04)
+2. [Open Online Config Version 1: Shadowsocks](docs/0002-open-online-config-v1-shadowsocks.md) (2021-07-04)
 
 ## How to Propose New Protocols
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Open Online Config manages and maintains open protocols for the distribution of 
 ## Protocols
 
 0. [README](README.md) (2021-06-27)
-1. [Open Online Config Version 1](docs/0001-open-online-config-v1.md) (2021-07-04)
-2. [Open Online Config Version 1: Shadowsocks](docs/0002-open-online-config-v1-shadowsocks.md) (2021-07-04)
+1. [Open Online Config Version 1](docs/0001-open-online-config-v1.md) (2021-08-20)
+2. [Open Online Config Version 1: Shadowsocks](docs/0002-open-online-config-v1-shadowsocks.md) (2021-08-20)
 
 ## How to Propose New Protocols
 

--- a/docs/0001-open-online-config-v1.md
+++ b/docs/0001-open-online-config-v1.md
@@ -103,12 +103,12 @@ Optional fields:
 - `bytesRemaining`: The amount of data remaining to be used by the user in bytes. MUST be greater than or equal to 0. An unsigned 64-bit integer MAY be used. MUST be accompanied by `bytesUsed`. Omit this field if no data limit is in place.
 - `expiryDate`: 64-bit Unix Epoch timestamp in seconds. The configuration is valid until this date. Clients MUST pull for updates and reload before this date. If the credentials are updated, the servers MUST stop accepting new connections with expired credentials. Existing connections with expired credentials MUST be maintained.
 
-You MAY include additional information with custom fields. Custom fields are not guaranteed to be supported by any client implementation. They MUST follow the `camelCase` naming convention, and MUST NOT have the same name as any registered protocol object name.
+Custom fields MAY be used to convey additional optional information. They MUST follow the `camelCase` naming convention, and MUST NOT have the same name as any registered protocol object name. The delivered config MUST NOT rely on any custom fields to function.
 
 ## 4. Protocol Registration
 
 A transport protocol MUST be registered and approved to become part of the standard.
 
-1. Prerequisites: You MUST be actively involved in the design and/or implementation of the protocol to qualify for registration. If the protocol is managed by an organization or a company, anyone approved by the entity to represent them is eligible.
-2. Registration: Open a pull request in this repository to add your standard document. The standard document MUST be written in English. The proposed changes MUST NOT cause conflicts or compatibility issues with existing configurations.
-4. Approval: Once the proposed changes are approved and merged, your registered protocol will officially become part of the standard of Open Online Config 1. You MAY refer to your protocol as `OOCv1:<protocol_name>`. For example, a registered `shadowsocks` protocol would be referred to as `OOCv1:shadowsocks`.
+1. Prerequisites: A person MUST be actively involved in the design and/or implementation of the protocol to qualify for registration. If the protocol is managed by an organization or a company, anyone approved by the entity to represent them is eligible.
+2. Registration: Open a pull request in this repository to add the standard document. The standard document MUST be written in English. The proposed changes MUST NOT cause conflicts or compatibility issues with existing configurations.
+4. Approval: Once the proposed changes are approved and merged, the registered protocol will officially become part of the standard of Open Online Config 1, and is referred to as `OOCv1:<protocol_name>`. For example, a registered `shadowsocks` protocol would be referred to as `OOCv1:shadowsocks`.

--- a/docs/0001-open-online-config-v1.md
+++ b/docs/0001-open-online-config-v1.md
@@ -50,7 +50,7 @@ To access a web API, the following information is needed:
 - Base URL: The base URL for API transactions. The protocol scheme MUST be HTTPS. The URL MUST NOT contain a trailing slash. For example, `https://example.com`, `https://1.1.1.1:853` and `https://[2001:db8::1]:8443` are a valid base URLs. `http://example.com` and `https://example.com/` are invalid for the mentioned reasons.
 - Secret: Path to the API endpoint. This is required to conceal the presence of the API. The secret MAY contain zero or more forward slashes (/) to allow flexible path hierarchy. But it's recommended to put non-secret part of the path in the base URL.
 - User ID: A distinctive string that represents the user. A UUID or a random secret string MAY be used.
-- Certificate SHA-256 Checksum: Optional. Specifying this checksum indicates the use of self-signed certificates. Use lowercase charaters without colons. For example, `0ae384bfd4dde9d13e50c5857c05a442c93f8e01445ee4b34540d22bd1e37f1b`.
+- Certificate SHA-256 Fingerprint: Optional. Pin the server certificate by verifying the certificate fingerprint. Required only when using a self-signed certificate. The hash value MUST be a hexadecimal string with lowercase letters. For example, `0ae384bfd4dde9d13e50c5857c05a442c93f8e01445ee4b34540d22bd1e37f1b`.
 
 An __API token__ MAY be used to convey the API access information in a single string.
 
@@ -66,7 +66,9 @@ An __API token__ MAY be used to convey the API access information in a single st
 
 The `version` field MUST match the version of the Open Online Config protocol.
 
-The `certSha256` field MUST be present for a self-signed certificate, and MUST be omitted when it's from a publicly-trusted CA. The JSON string MAY be minified to fit in one line.
+The `certSha256` field is required when using a self-signed certificate. With a publicly-trusted certificate, this field SHOULD be omitted.
+
+The JSON string MAY be minified to fit in one line.
 
 ## 3. API Specification
 

--- a/docs/0001-open-online-config-v1.md
+++ b/docs/0001-open-online-config-v1.md
@@ -1,0 +1,114 @@
+# Open Online Config 1: An HTTPS-based Application Protocol for Configuration Delivery of Censorship Circumvention Services
+
+## 0. Abstract
+
+This document defines version 1 of the Open Online Config protocol. Open Online Config 1 (OOCv1) provides service providers and application developers with a simple and elegant solution for the delivery of censorship circumvention service configurations with unified support for different transport protocols.
+
+## 1. Overview
+
+Open Online Config 1 is an HTTPS-based application protocol for the distribution of censorship circumvention services. The protocol aims to provide a centralized model for the sharing of distributed censorship circumvention services in a community.
+
+Servers are required to implement a basic web API for clients to retrieve configuration in the defined format. Additional API methods may be implemented for advanced operations.
+
+### 1.1. Document Structure
+
+This document describes the Open Online Config protocol version 1 and is structured as follows:
+
+- Section 2 describes transport and delivery details.
+- Section 3 defines the API specification, including request and response format.
+- Section 4 defines how transport protocols are registered and standardized.
+
+### 1.2. Terms and Definitions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/info/rfc2119) [RFC8174](https://www.rfc-editor.org/info/rfc8174) when, and only when, they appear in all capitals, as shown here.
+
+Commonly used terms in this document are described below.
+
+- OOCv1: An acronym for the Open Online Config protocol version 1 defined by this document.
+- Client: The endpoint that retrieves configuration for use.
+- Server: The endpoint that accepts OOCv1 requests and sends configuration.
+- Node: A participating server that acts as a transit for Internet traffic.
+
+## 2. Transport and Delivery
+
+Clients communicate with servers by making API transactions.
+
+### 2.1 Transport
+
+The web API MUST use HTTPS as the underlying transport. The minimum TLS version SHOULD be 1.3 to disallow week encryption and protect against TLS downgrade attacks.
+
+Certificates from a publicly-trusted CA SHOULD be used. Self-signed certificates MAY be used, in which case an accompanying certificate SHA-256 checksum must be provided for verification.
+
+Clients MUST NOT omit certificate issues or TLS errors to protect against TLS MITM attacks. Clients MAY support importing from or exporting as JSON files as a temporary way of exchanging configuration in case of need.
+
+Servers MUST respond with the correct format, content type and the UTF-8 charater set.
+
+### 2.2 Delivery
+
+To access a web API, the following information is needed:
+
+- Base URL: The base URL for API transactions. The protocol scheme MUST be HTTPS. The URL MUST NOT contain a trailing slash. For example, `https://example.com`, `https://1.1.1.1:853` and `https://[2001:db8::1]:8443` are a valid base URLs. `http://example.com` and `https://example.com/` are invalid for the mentioned reasons.
+- Secret: Path to the API endpoint. This is required to conceal the presence of the API. The secret MAY contain zero or more forward slashes (/) to allow flexible path hierarchy. But it's recommended to put non-secret part of the path in the base URL.
+- User ID: A distinctive string that represents the user. A UUID or a random secret string MAY be used.
+- Certificate SHA-256 Checksum: Optional. Specifying this checksum indicates the use of self-signed certificates. Use lowercase charaters without colons. For example, `0ae384bfd4dde9d13e50c5857c05a442c93f8e01445ee4b34540d22bd1e37f1b`.
+
+An __API token__ MAY be used to convey the API access information in a single string.
+
+``` json
+{
+    "version": 1,
+    "baseUrl": "https://example.com",
+    "secret": "8c1da4d8-8684-4a2c-9abb-57b9d5fa7e52",
+    "userId": "a117460e-41df-4dbd-b2df-4bd0c16efd2f",
+    "certSha256": "0ae384bfd4dde9d13e50c5857c05a442c93f8e01445ee4b34540d22bd1e37f1b"
+}
+```
+
+The `version` field MUST match the version of the Open Online Config protocol.
+
+The `certSha256` field MUST be present for a self-signed certificate, and MUST be omitted when it's from a publicly-trusted CA. The JSON string MAY be minified to fit in one line.
+
+## 3. API Specification
+
+A `GET` method is required for basic configuration delivery. Implementations MAY implement additional methods.
+
+Request:
+
+``` http
+GET /<secret>/ooc/v1/<user_id>
+```
+
+Response JSON:
+
+``` json
+{
+    "username": "nobody",
+    "bytesUsed": 274877906944,
+    "bytesRemaining": 824633720832,
+    "expiryDate": 1625356800,
+    "protocols": [ "shadowsocks", "vmess", "trojan-go" ]
+}
+```
+
+Required fields:
+
+- `protocols`: Protocols utilized by this configuration. Only registered protocols are allowed. See Section 4 for details about protocol registration.
+
+Clients MUST check the `protocols` field against supported protocols. If not all protocols used by the configuration are supported, a warning message MUST be displayed.
+
+Optional fields:
+
+- `username`: Username.
+- `bytesUsed`: The amount of data used by the user in bytes. MUST be greater than or equal to 0. An unsigned 64-bit integer MAY be used. Omit this field if no data usage metrics are available.
+- `bytesRemaining`: The amount of data remaining to be used by the user in bytes. MUST be greater than or equal to 0. An unsigned 64-bit integer MAY be used. MUST be accompanied by `bytesUsed`. Omit this field if no data limit is in place.
+- `expiryDate`: 64-bit Unix Epoch timestamp in seconds. The configuration is valid until this date. Clients MUST pull for updates and reload before this date. If the credentials are updated, the servers MUST stop accepting new connections with expired credentials. Existing connections with expired credentials MUST be maintained.
+
+You MAY include additional information with custom fields. Custom fields are not guaranteed to be supported by any client implementation. They MUST follow the `camelCase` naming convention, and MUST NOT have the same name as any registered protocol object name.
+
+## 4. Protocol Registration
+
+A transport protocol MUST be registered and approved to become part of the standard.
+
+1. Prerequisites: You MUST be actively involved in the design and/or implementation of the protocol to qualify for registration. If the protocol is managed by an organization or a company, anyone approved by the entity to represent them is eligible.
+2. Registration: Open a pull request in this repository to add your standard document. The standard document MUST be written in English. The proposed changes MUST NOT cause conflicts or compatibility issues with existing configurations.
+4. Approval: Once the proposed changes are approved and merged, your registered protocol will officially become part of the standard of Open Online Config 1. You MAY refer to your protocol as `OOCv1:<protocol_name>`. For example, a registered `shadowsocks` protocol would be referred to as `OOCv1:shadowsocks`.

--- a/docs/0001-open-online-config-v1.md
+++ b/docs/0001-open-online-config-v1.md
@@ -35,7 +35,7 @@ Clients communicate with servers by making API transactions.
 
 ### 2.1 Transport
 
-The web API MUST use HTTPS as the underlying transport. The minimum TLS version SHOULD be 1.3 to disallow week encryption and protect against TLS downgrade attacks.
+The web API MUST use HTTPS as the underlying transport. The minimum TLS version SHOULD be 1.3 to disallow week encryption and protect against TLS downgrade attacks. [HSTS (HTTP Strict Transport Security)](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) SHOULD be deployed on the web server. Optimally, submit the domain name to the [HSTS preload list](https://hstspreload.org/). This prevents browsers from sending the initial request via an unsecured plain HTTP connection if the user enters the domain in the address bar without the protocol prefix.
 
 Certificates from a publicly-trusted CA SHOULD be used. Self-signed certificates MAY be used, in which case an accompanying certificate SHA-256 checksum must be provided for verification.
 

--- a/docs/0001-open-online-config-v1.md
+++ b/docs/0001-open-online-config-v1.md
@@ -2,13 +2,13 @@
 
 ## 0. Abstract
 
-This document defines version 1 of the Open Online Config protocol. Open Online Config 1 (OOCv1) provides service providers and application developers with a simple and elegant solution for the delivery of censorship circumvention service configurations with unified support for different transport protocols.
+This document defines version 1 of the Open Online Config protocol. Open Online Config 1 (OOCv1) provides a simple and elegant solution for service providers and application developers to deliver censorship circumvention service configurations to users. Open Online Config 1 enables unified support for different transport protocols with a registration and standardization process.
 
 ## 1. Overview
 
-Open Online Config 1 is an HTTPS-based application protocol for the distribution of censorship circumvention services. The protocol aims to provide a centralized model for the sharing of distributed censorship circumvention services in a community.
+Open Online Config 1 is an HTTPS-based application protocol for the distribution of censorship circumvention services. The protocol aims to provide a centralized model for the sharing of distributed censorship circumvention services in communities.
 
-Servers are required to implement a basic web API for clients to retrieve configuration in the defined format. Additional API methods may be implemented for advanced operations.
+An Open Online Config 1 server exposes a web API for clients to retrieve configurations. A series of requirements for the web API are specified in this document to ensure the secure transport of sensitive information. The API response is based on the minimal JSON format defined in this document. Extension standards add additional fields to support different transport protocols.
 
 ### 1.1. Document Structure
 
@@ -47,7 +47,7 @@ Servers MUST respond with the correct format, content type and the UTF-8 charate
 
 To access a web API, the following information is needed:
 
-- Base URL: The base URL for API transactions. The protocol scheme MUST be HTTPS. The URL MUST NOT contain a trailing slash. For example, `https://example.com`, `https://1.1.1.1:853` and `https://[2001:db8::1]:8443` are a valid base URLs. `http://example.com` and `https://example.com/` are invalid for the mentioned reasons.
+- Base URL: The base URL for API transactions. The protocol scheme MUST be HTTPS. The URL MUST NOT contain a trailing slash. For example, `https://example.com`, `https://1.1.1.1:853` and `https://[2001:db8::1]:8443` are valid base URLs. `http://example.com` and `https://example.com/` are invalid because they do not meet the protocol scheme and trailing slash requirements.
 - Secret: Path to the API endpoint. This is required to conceal the presence of the API. The secret MAY contain zero or more forward slashes (/) to allow flexible path hierarchy. But it's recommended to put non-secret part of the path in the base URL.
 - User ID: A distinctive string that represents the user. A UUID or a random secret string MAY be used.
 - Certificate SHA-256 Fingerprint: Optional. Pin the server certificate by verifying the certificate fingerprint. Required only when using a self-signed certificate. The hash value MUST be a hexadecimal string with lowercase letters. For example, `0ae384bfd4dde9d13e50c5857c05a442c93f8e01445ee4b34540d22bd1e37f1b`.

--- a/docs/0002-open-online-config-v1-shadowsocks.md
+++ b/docs/0002-open-online-config-v1-shadowsocks.md
@@ -1,0 +1,59 @@
+# Open Online Config 1: Shadowsocks
+
+## 1. Overview
+
+Shadowsocks is a simple stateless proxy protocol that uses symmetric key ciphers to encrypt network traffic.
+
+This document defines the JSON document format for Shadowsocks AEAD configurations in Open Online Config 1, with support for plugins.
+
+## 2. API Specification
+
+Request:
+
+``` http
+GET /<secret>/ooc/v1/<user_id>
+```
+
+Response JSON:
+
+``` json
+{
+    "protocols": [ "shadowsocks" ],
+    "shadowsocks": [
+        {
+            "id": "27b8a625-4f4b-4428-9f0f-8a2317db7c79",
+            "name": "ServerName",
+            "address": "example.com",
+            "port": 8388,
+            "method": "chacha20-ietf-poly1305",
+            "password": "example",
+            "pluginPath": "/path/to/plugin-binary",
+            "pluginOpts": "whatever",
+            "pluginArgs": "-vvvvvv"
+        }
+    ]
+}
+```
+
+The protocol name is `shadowsocks`. Shadowsocks servers are placed in an array named `shadowsocks`. Only Shadowsocks AEAD servers are allowed. Custom fields are allowed but MUST NOT be related to the protocol itself.
+
+Required fields:
+
+- `id`: UUID of the server. Used by clients to distinguish and persist servers when reloading.
+- `name`: Server name.
+- `address`: Server address. Do not enclose IPv6 addresses in brackets. Examples: `example.com`, `1.1.1.1`, `2001:db8::1`.
+- `port`: Server port number.
+- `method`: AEAD encryption method. Valid values: `aes-128-gcm`, `aes-256-gcm`, `chacha20-ietf-poly1305`.
+- `password`: Password. Not the derived key.
+
+Optional plugin fields:
+
+- `pluginPath`: Relative or absolute path to plugin executable binary. Required when using a plugin.
+- `pluginOpts`: Value of environment variable `SS_PLUGIN_OPTIONS`. Optional when using a plugin.
+- `pluginArgs`: Plugin executable startup arguments. Optional when using a plugin.
+
+Implementations should follow [SIP003](https://shadowsocks.org/en/wiki/Plugin.html), with the exception of `pluginArgs` field to allow more flexible configurations.
+
+Plugin support at both sides is optional. But clients without plugin support MUST be able to recognize servers with plugins and reject them.
+
+If a server doesn't use a plugin, all plugin fields MUST be omitted.

--- a/docs/0002-open-online-config-v1-shadowsocks.md
+++ b/docs/0002-open-online-config-v1-shadowsocks.md
@@ -27,9 +27,10 @@ Response JSON:
             "port": 8388,
             "method": "chacha20-ietf-poly1305",
             "password": "example",
-            "pluginPath": "/path/to/plugin-binary",
-            "pluginOpts": "whatever",
-            "pluginArgs": "-vvvvvv"
+            "pluginName": "plugin-name",
+            "pluginVersion": "1.0",
+            "pluginOptions": "whatever",
+            "pluginArguments": "-vvvvvv"
         }
     ]
 }
@@ -48,12 +49,15 @@ Required fields:
 
 Optional plugin fields:
 
-- `pluginPath`: Relative or absolute path to plugin executable binary. Required when using a plugin.
-- `pluginOpts`: Value of environment variable `SS_PLUGIN_OPTIONS`. Optional when using a plugin.
-- `pluginArgs`: Plugin executable startup arguments. Optional when using a plugin.
+- `pluginName`: Plugin name. Required when using a plugin.
+- `pluginVersion`: Required version of the plugin. Optional when using a plugin.
+- `pluginOptions`: Value of environment variable `SS_PLUGIN_OPTIONS`. Optional when using a plugin.
+- `pluginArguments`: Plugin executable startup arguments. Optional when using a plugin.
 
-Implementations should follow [SIP003](https://shadowsocks.org/en/wiki/Plugin.html), with the exception of `pluginArgs` field to allow more flexible configurations.
+Implementations MUST follow [SIP003](https://shadowsocks.org/en/wiki/Plugin.html), with the addition of `pluginArguments` field to allow more flexible configurations.
 
 Plugin support at both sides is optional. But clients without plugin support MUST be able to recognize servers with plugins and reject them.
+
+Client implementations with plugin support MUST maintain a user-configurable list of locally installed plugins with their name, version, and binary path on it. When connecting to a plugin-enabled server, the client resolves the plugin from the list by matching plugin name and version.
 
 If a server doesn't use a plugin, all plugin fields MUST be omitted.


### PR DESCRIPTION
Open Online Config 1 is an HTTPS-based application protocol for the distribution of censorship circumvention services. The protocol aims to provide a centralized model for the sharing of distributed censorship circumvention services in a community.

Open Online Config 1 supersedes SIP008 ([standard document](https://shadowsocks.org/en/wiki/SIP008-Online-Configuration-Delivery.html), [tracking issue](https://github.com/shadowsocks/shadowsocks-org/issues/89)) and [SIP008ext](https://github.com/shadowsocks/shadowsocks-org/issues/168).

Feel free to review and post suggestions! 😊

## Quick Links

- [Rendered Markdown: Open Online Config v1](https://github.com/Shadowsocks-NET/OpenOnlineConfig/blob/ooc-v1/docs/0001-open-online-config-v1.md)
- [Rendered Markdown: OOCv1:shadowsocks](https://github.com/Shadowsocks-NET/OpenOnlineConfig/blob/ooc-v1/docs/0002-open-online-config-v1-shadowsocks.md)

## Open Questions

1. Should the spec include additional API methods?
2. Should the spec allow SHA-256 fingerprint pinning of certificates from publicly-trusted CAs?
3. Should the spec include well-defined configuration expiration behavior for clients and servers?
4. Should the spec define redirection behavior on receiving HTTP `301 Moved Permanently`?